### PR TITLE
Remove beta-labels from firmware

### DIFF
--- a/docs/endpoints/api-v1-data.mdx
+++ b/docs/endpoints/api-v1-data.mdx
@@ -169,10 +169,6 @@ Content-Length: <length>
 
 ### Data points
 
-:::info Firmware 4.00 is in beta
-The firmware version 4.00 is currently in beta and is tested by a small group of users. The firmware will be released to all users when the beta phase is completed.
-:::
-
 | Data                      | Type   | Available for | Description                                                                 | Required firmware version |
 | ------------------------- | ------ | ------------- | --------------------------------------------------------------------------- | ------------------------- |
 | wifi_ssid                 | String | All           | The Wi-Fi network that the meter is connected to                            | 3.03 or later             |

--- a/docs/endpoints/api-v1-identify.mdx
+++ b/docs/endpoints/api-v1-identify.mdx
@@ -13,10 +13,6 @@ This feature is available for:
 -   Energy Socket (HWE-SKT)
 -   Watermeter (HWE-WTR) (firmware version 3.00 or later required)
 
-:::info Watermeter support
-Support for this endpoint in the Watermeter will be added in version 3.00. This version is currently in beta and is tested by a small group of users. The firmware will be released to all users when the beta phase is completed.
-:::
-
 ### Example
 
 ```

--- a/docs/endpoints/api-v1-system.mdx
+++ b/docs/endpoints/api-v1-system.mdx
@@ -15,10 +15,6 @@ This feature is currently only available for:
 -   kWh Meter (HWE-KWH3 / SDM630-wifi)
 -   Watermeter (HWE-WTR) (firmware version 3.00 or later required)
 
-:::info Watermeter support
-Support for this endpoint in the Watermeter will be added in version 3.00. This version is currently in beta and is tested by a small group of users. The firmware will be released to all users when the beta phase is completed.
-:::
-
 ## Enable cloud
 
 The HomeWizard Energy devices are designed to work with the HomeWizard Energy app and require communication with the HomeWizard cloud to make them function with the app.


### PR DESCRIPTION
Energy Socket and Watermeter firmwares are now generally available.