### PR TITLE
Improve beta-indication of v2 support in P1

### DIFF
--- a/docs/v2/authorization.mdx
+++ b/docs/v2/authorization.mdx
@@ -10,7 +10,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # Authorization `/api/user`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>kWh Meter</Badge>

--- a/docs/v2/device_information.mdx
+++ b/docs/v2/device_information.mdx
@@ -10,7 +10,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # Device Information `/api`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>kWh Meter</Badge>

--- a/docs/v2/error-handling.mdx
+++ b/docs/v2/error-handling.mdx
@@ -9,7 +9,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # Error Handling
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>kWh Meter</Badge>

--- a/docs/v2/measurement.mdx
+++ b/docs/v2/measurement.mdx
@@ -11,7 +11,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # Recent Measurement `/api/measurement`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>kWh Meter</Badge>

--- a/docs/v2/system.mdx
+++ b/docs/v2/system.mdx
@@ -10,7 +10,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # System `/api/system`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-orange' icon='mdi:check' subtext='Supported in v1'>kWh Meter</Badge>

--- a/docs/v2/telegram.mdx
+++ b/docs/v2/telegram.mdx
@@ -11,7 +11,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # Telegram `/api/telegram`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-grey' icon='mdi:close' subtext='Not supported'>Energy Socket</Badge>
 <Badge color='hw-grey' icon='mdi:close' subtext='Not supported'>Energy Display</Badge>
 <Badge color='hw-grey' icon='mdi:close' subtext='Not supported'>kWh Meter</Badge>

--- a/docs/v2/websocket.mdx
+++ b/docs/v2/websocket.mdx
@@ -11,7 +11,7 @@ import PreliminaryWarning from '@site/src/components/PreliminaryWarning.js'
 # WebSocket `/api/ws`
 
 {/* prettier-ignore */}
-<Badge color='hw-green' icon='mdi:check' subtext='Supported'>P1 Meter</Badge>
+<Badge color='hw-green' icon='mdi:test-tube' subtext='Requires Firmware 6.00, Currently in Beta'>P1 Meter</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Socket</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>Energy Display</Badge>
 <Badge color='hw-purple' icon='mdi:wrench' subtext='In development'>kWh Meter</Badge>


### PR DESCRIPTION
It was not really clear that the P1 Meter has no support for v2 API at this moment, only when running beta firmware. Added an extra statement to the badges to make this easier to understand.