### PR TITLE
Adjust getting started guide to be more generic

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -10,13 +10,13 @@ This guide will help you get started with the HomeWizard Energy API.
 
 ## Choosing the Right API Version
 
-The HomeWizard Energy API has two versions: v1 and v2. The v1 API is the **stable version and is recommended to be used**. The v2 API is in currently in beta. Skip to [getting started with v2](#getting-started-with-v2) if you want to use the v2 API.
+The HomeWizard Energy API has two versions: v1 and v2. The v1 API is available as long as feasible, but will be phased out. The v2 API is the stable version and is recommended to be used. Skip to [getting started with v2](#getting-started-with-v2) if you want to use the v2 API.
 
 ## Getting Started with v1
 
 ### 1. Connect your Device to Wi-Fi
 
-Connect your Device to Wi-Fi with the <Link href="https://www.homewizard.nl/energy">HomeWizard Energy App</Link>. Make sure to connect your Energy device with the same network as the device that makes use of the API.
+Connect your Device to Wi-Fi with the <Link href="https://www.homewizard.nl/energy">HomeWizard Energy App</Link>. Make sure to connect your device with the same network as the device that makes use of the API.
 
 ### 2. Enable the API
 
@@ -36,16 +36,16 @@ To understand each value, please read [endpoints](/docs/category/api-v1/).
 
 In contrast to v1, the v2 API is based on HTTPS and uses authorization to access the data. This means you don't need to enable the local API in the app, but you have to obtain a token.
 
-The following example will show you can use the API to get basic information from a P1 Meter.
+The following example will show you can use the API to get basic information.
 
 ### 1. Connect your Device to Wi-Fi
 
-Connect your device to Wi-Fi with the <Link href="https://www.homewizard.nl/energy">HomeWizard Energy app</Link>. Make sure to connect your Energy device with the same network as the device that makes use of the API.
+Connect your device to Wi-Fi with the <Link href="https://www.homewizard.nl/energy">HomeWizard Energy app</Link>. Make sure to connect your device with the same network as the device that makes use of the API.
 
 ### 2. Get a Token
 
 :::danger
-The token allows full access to the data from your P1 Meter and **should be kept secret**. Do not share this token with others. [Remove this token](/docs/v2/authorization#delete-user) when you no longer need it.
+The token allows full access to the data from your device and **should be kept secret**. Do not share this token with others. [Remove this token](/docs/v2/authorization#delete-user) when you no longer need it.
 :::
 
 1. Get the IP address of the device.
@@ -56,7 +56,7 @@ curl https://<IP ADDRESS>/api/user --insecure -X POST -d '{"name": "local/cool-n
 ```
 
 3. You will get the following message: `{"error":"user:creation-not-enabled"}`.
-4. Press the button on the P1 Meter once.
+4. Press the button on the device once.
 5. Send the same request again to get a token:
 
 ```


### PR DESCRIPTION
It was still talking about a P1 Meter, but the guide is also applicable for other devices.