### PR TITLE
Add changelog for API 2.0.1

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -18,6 +18,7 @@ Feature development of the v1 API has been stopped. No new features will be adde
 ### v2
 
 -   **2.0.0** - 21-01-2025 - Initial release of the v2 API.
+-   **2.0.1** - 30-01-2025 - An issue has been resolved where `energy_import_kwh` and `energy_export_kwh` values in the Plug-In Battery [Measurement API](/docs/v2/measurement#plug-in-battery-hwe-bat) were returning invalid values. The values are now the same as those in the HomeWizard Energy app.
 
 ## Subscribe to Updates
 


### PR DESCRIPTION
**2.0.1**: An issue has been resolved where `energy_import_kwh` and `energy_export_kwh` values in the Plug-In Battery [Measurement API](/docs/v2/measurement#plug-in-battery-hwe-bat) were returning invalid values. The values are now the same as those in the HomeWizard Energy app.