### PR TITLE
Update telegram.mdx

### DIFF
--- a/docs/v1/telegram.mdx
+++ b/docs/v1/telegram.mdx
@@ -29,7 +29,7 @@ The `/api/v1/telegram` endpoint returns the most recent, valid telegram that was
 ## Example
 
 ```http title="Request"
-curl http://<IP ADDRESS>/api/telegram
+curl http://<IP ADDRESS>/api/v1/telegram
 ```
 
 ```http title="Response"


### PR DESCRIPTION
`curl http://<IP ADDRESS>/api/telegram` does not work, missing v1.