### PR TITLE
Rename voltage_l1_v to voltage_v in measurement docs

### DIFF
--- a/docs/v2/measurement.mdx
+++ b/docs/v2/measurement.mdx
@@ -160,7 +160,7 @@ Belgian users may be charged for the peak usage per month (see <Link to="https:/
 | energy_import_kwh   | Number | The energy usage meter reading in kWh.   |
 | energy_export_kwh   | Number | The energy feed-in meter reading in kWh. |
 | power_w             | Number | The total active usage in watt.          |
-| voltage_l1_v        | Number | The active voltage in volt.              |
+| voltage_v           | Number | The active voltage in volt.              |
 | current_a           | Number | The active current in ampere.            |
 | frequency_hz        | Number | Line frequency in hertz.                 |
 | state_of_charge_pct | Number | The current state of charge in percent.  |


### PR DESCRIPTION
As followup on #202, good catch @jtebbens